### PR TITLE
docs: sync repo docs with v0.3.0-mvp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ assignees: ''
 <!-- What actually happened. Include error messages, screenshots, or logs if possible. -->
 
 ### Environment
-- SDK Version:
+- SDK Version: (e.g., v0.3.0-mvp)
 - OS / Browser:
 - Node.js version:
 - Stellar Network: testnet / mainnet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows a simplified version of Keep a Changelog, and the project adh
 
 ---
 
+## [v0.3.0-mvp] — 2026-01-20
+
+### 🛡️ Production-Lite Hardening
+- **Polling Lock:** Implemented concurrency control for `PaymentMonitor` to prevent race conditions in multi-instance deployments.
+- **Lock TTL:** Added configurable `lockTtlMs` to auto-expire locks if an instance crashes.
+- **Monitor Options:** Added `pollIntervalMs`, `horizonTimeoutMs`, `lockTtlMs`, and `instanceId` to `PaymentMonitor` configuration.
+- **Persistence:** Enhanced `PersistenceAdapter` interface with `acquireLock` and `releaseLock` methods.
+
+## [v0.2.0-mvp] — 2026-01-19
+
+### 🔒 Security & Hardening
+- **SQLite Persistence:** `PaymentMonitor` now uses SQLite by default to persist state across restarts.
+- **Rate Limiting:** Added `RateLimiter` to restrict payment session registration frequency.
+- **TTL Cleanup:** Implemented automatic cleanup of expired payments and locks.
+- **Error Handling:** Introduced `RateLimitError` and improved error reporting.
+- **Persistence Adapter:** Refactored persistence logic into a pluggable `PersistenceAdapter` interface.
+
 ## [v0.1.0-mvp] — 2026-01-18
 
 ### 🚀 Added

--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
-[![Release](https://img.shields.io/badge/release-v0.2.0--mvp-blue)](https://github.com/ZacksonPessoa/USDC-Payments-SDK-for-Stellar-Web-Mobile-/releases/tag/v0.2.0-mvp)
+[![Release](https://img.shields.io/badge/release-v0.3.0--mvp-blue)](https://github.com/ZacksonPessoa/USDC-Payments-SDK-for-Stellar-Web-Mobile-/releases/tag/v0.3.0-mvp)
 [![Security](https://img.shields.io/badge/security-MVP--secure-green)](https://github.com/ZacksonPessoa/USDC-Payments-SDK-for-Stellar-Web-Mobile-/security)
 
 # USDC Payments SDK for Stellar (Web + Mobile)
 
 **One-line checkout SDK to make paying with USDC on Stellar as easy as Stripe.**
 
-[![npm version](https://badge.fury.io/js/%40zacksonpessoa%2Fusdc-payments-sdk.svg)](https://badge.fury.io/js/%40zacksonpessoa%2Fusdc-payments-sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9+-blue.svg)](https://www.typescriptlang.org/)
+
+---
+
+## 🚧 Public Beta (Testnet)
+
+**This SDK is currently in Public Beta.**
+
+*   **Status:** Pilot / Testing (v0.3.0-mvp)
+*   **Network:** Stellar Testnet (Primary), Mainnet (Experimental)
+*   **Use Case:** Development, Integration Testing, Pilot Programs.
+
+**Not yet intended for large-scale production use.**
+We are currently hardening the server-side components ("Production-Lite") and finalizing mobile support.
+
+### How to test (Quickstart)
+See the [Examples](./examples/) directory for a complete reference implementation:
+1.  Clone the repo.
+2.  `npm install`
+3.  `node examples/secure-server-example.mjs` (Simulates a full payment flow).
+
+### How to report issues
+Please report bugs or feature requests using our [GitHub Issues](https://github.com/ZacksonPessoa/USDC-Payments-SDK-for-Stellar-Web-Mobile-/issues).
+*   Use the **Bug Report** template for unexpected behavior.
+*   Use the **Feature Request** template for new ideas.
 
 ---
 
@@ -17,6 +40,9 @@
 - **`createPaymentSession()`** - Build Stellar payment transactions
 - **`signAndSubmit()`** - Sign and submit transactions to Horizon
 - **`PaymentMonitor`** - Secure Server-Side Payment Verification with SQLite Persistence
+- **`PersistenceAdapter`** - Pluggable storage backend (SQLite default)
+- **Rate Limiting** - Built-in protection for payment session registration
+- **Production-Lite Mode** - Polling locks for multi-instance safety
 - **`PaymentStatusTracker`** - Track payment status through the entire flow (NEW!)
 - **`SEP24Helper`** - SEP-24 on/off-ramp integration helpers (NEW!)
 - **Custom Error Classes** - Detailed error handling with specific error types (NEW!)
@@ -220,6 +246,20 @@ To scale beyond "lite" usage (SQLite on shared disk), implement the `Persistence
 #### `PaymentMonitor`
 Monitors an account for specific incoming payments, with built-in SQLite persistence.
 
+**Constructor:**
+`new PaymentMonitor(network, monitoredAccount, webhookConfig, options)`
+
+**Options (`MonitorOptions`):**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `timeoutMinutes` | `number` | `15` | Expiration time for pending payments |
+| `pollIntervalMs` | `number` | `5000` | Polling interval in milliseconds |
+| `horizonTimeoutMs` | `number` | `15000` | Horizon request timeout |
+| `lockTtlMs` | `number` | `20000` | Lock TTL for concurrency control |
+| `instanceId` | `string` | `UUID` | Unique ID for this monitor instance |
+| `adapter` | `PersistenceAdapter` | `Database` | Custom persistence adapter |
+| `rateLimit` | `RateLimitConfig` | `{windowMs: 60000, max: 100}` | Rate limit configuration |
+
 #### `generateSignature(payload, secret)` / `verifySignature(payload, signature, secret)`
 Crypto helpers for secure webhook communication.
 
@@ -272,6 +312,19 @@ The SDK builds to:
 - [x] **Retry logic** ✅ - Automatic retry with exponential backoff for transactions
 - [x] **Unit tests** ✅ - Test suite configured with Vitest
 - [x] **PaymentMonitor tests** ✅ - Tests for PaymentMonitor and WebhookSender implemented
+
+### 📈 Releases / Hardening Track
+
+- **v0.2.0-mvp**: MVP Hardening
+    - [x] Rate limiting
+    - [x] TTL cleanup
+    - [x] SQLite PersistenceAdapter (default)
+    - [x] RateLimitError
+
+- **v0.3.0-mvp**: Production-Lite
+    - [x] Polling lock (concurrency control)
+    - [x] Multi-instance safety (SQLite/DB backed)
+    - [x] Configurable polling & lock TTL
 
 ### 📋 Phase 3 - Mobile Support (PLANNED)
 

--- a/src/server/paymentMonitor.test.ts
+++ b/src/server/paymentMonitor.test.ts
@@ -126,7 +126,8 @@ describe("PaymentMonitor", () => {
 
     expect(monitor).toBeInstanceOf(PaymentMonitor);
     expect(StellarSDK.Horizon.Server).toHaveBeenCalledWith(
-      "https://horizon.stellar.org"
+      "https://horizon.stellar.org",
+      { allowHttp: true, timeout: 15000 }
     );
   });
 
@@ -138,7 +139,8 @@ describe("PaymentMonitor", () => {
     );
 
     expect(StellarSDK.Horizon.Server).toHaveBeenCalledWith(
-      "https://horizon-testnet.stellar.org"
+      "https://horizon-testnet.stellar.org",
+      { allowHttp: true, timeout: 15000 }
     );
   });
 


### PR DESCRIPTION
This PR synchronizes the repository documentation and metadata with the latest v0.3.0-mvp release.

**Changes:**
- **README.md:**
    - Updated Release badge to `v0.3.0-mvp`.
    - Added **Public Beta** section with testing and reporting guidance.
    - Updated **Features** list to include SQLite persistence, Rate Limiting, and Production-Lite hardening.
    - Detailed **PaymentMonitor** configuration options (`pollIntervalMs`, `lockTtlMs`, etc.).
    - Updated **Project Status** to show "Releases / Hardening Track".
- **CHANGELOG.md:**
    - Added entries for `v0.3.0-mvp` (Production-Lite) and `v0.2.0-mvp` (Hardening).
- **Issue Templates:**
    - Ensured `.github/ISSUE_TEMPLATE` files are present and updated `bug_report.md` with a version placeholder.
- **Tests:**
    - Fixed `src/server/paymentMonitor.test.ts` to correctly expect default options passed to `Horizon.Server`, ensuring `npm test` passes.


---
*PR created automatically by Jules for task [14848809707534606901](https://jules.google.com/task/14848809707534606901) started by @ZacksonPessoa*